### PR TITLE
Reintegrate other BlockchainTests / new dir CL argument (to master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # ethereumjs-testing
-testing utilities for the ethereumjs stack
 
-Uses the offical [Ethereum Tests](https://github.com/ethereum/tests)
+Testing utilities for the ethereumjs stack.
+
+Uses the offical [Ethereum Tests](https://github.com/ethereum/tests).
 
 To fetch the latest tests:
 ```
@@ -10,3 +11,30 @@ git submodule update
 cd tests
 git pull origin develop
 ```
+
+## API
+
+```
+const testing = require('ethereumjs-testing')
+```
+
+#### `testing.getTestsFromArgs(testType, onFile, args = {})`
+Reads tests of a certain test type from several folders and files
+- `testType` - Type of the test (``GeneralStateTests``, ``BlockchainTests``, ``VMTests``)
+- `onFile` - Function to run the tests (see example)
+- `args`
+  - `forkConfig` - Run tests for selected fork (``BlockchainTests`` only)
+  - `dir` - Only run tests from subdirectory
+  - `file` - File filter to apply
+  - `test` - Only run a single test case
+  - `skipTests` - List of tests to skip
+  - `skipVM` - List of VM tests to skip
+
+#### `testing.getSingleFile(file)`
+Reads a single test file
+- `file` - Path to the file
+
+
+Examples how to read tests with the API methods above can be found in 
+the [./examples](./examples/) directory.
+  

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Reads tests of a certain test type from several folders and files
   - `forkConfig` - Run tests for selected fork (``BlockchainTests`` only)
   - `dir` - Only run tests from subdirectory
   - `file` - File filter to apply
+  - `excludeDir` - Exclude directory filter to apply
   - `test` - Only run a single test case
   - `skipTests` - List of tests to skip
   - `skipVM` - List of VM tests to skip

--- a/examples/read-single-file.js
+++ b/examples/read-single-file.js
@@ -1,0 +1,4 @@
+const testing = require('../index.js')
+
+const testData = testing.getSingleFile('GeneralStateTests/stCodeSizeLimit/codesizeValid.json')
+console.log(testData)

--- a/examples/read-tests-with-args.js
+++ b/examples/read-tests-with-args.js
@@ -1,0 +1,14 @@
+const testing = require('../index.js')
+
+let args = {}
+args.dir = 'GeneralStateTests/stCallCodes'
+args.forkConfig = 'Byzantium'
+
+testing.getTestsFromArgs('BlockchainTests', (fileName, testName, test) => {
+  return new Promise((resolve, reject) => {
+    console.log(fileName)
+    resolve()
+  }).catch(err => console.log(err))
+}, args).then(() => {
+  console.log("Do something afterwards (e.g. t.end()).");
+})

--- a/index.js
+++ b/index.js
@@ -8,11 +8,12 @@ const path = require('path')
  * @param {Object} tests the tests usally fetched using `getTests`
  * @param {Function} filter to enable test skipping, called with skipFn(index, testName, testData)
  */
-const getTests = exports.getTests = (testType, onFile, fileFilter = /.json$/, skipFn = () => {
+const getTests = exports.getTests = (testType, onFile, testDir = '', fileFilter = /.json$/, skipFn = () => {
   return false
 }) => {
   return new Promise((resolve, reject) => {
-    dir.readFiles(path.join(__dirname, 'tests', testType), {
+    var testPath = path.join(__dirname, 'tests', testType, testDir)
+    dir.readFiles(testPath, {
       match: fileFilter
     }, async (err, content, fileName, next) => {
       if (err) reject(err)
@@ -33,12 +34,12 @@ const getTests = exports.getTests = (testType, onFile, fileFilter = /.json$/, sk
   })
 }
 
-function skipTest (testName, skipList) {
+function skipTest (testName, skipList = []) {
   return skipList.map((skipName) => (new RegExp(`^${skipName}`)).test(testName)).some(isMatch => isMatch)
 }
 
 exports.getTestsFromArgs = function (testType, onFile, args = {}) {
-  let fileFilter, skipFn
+  let testDir, fileFilter, skipFn
 
   skipFn = (name) => {
     return skipTest(name, args.skipTests)
@@ -56,7 +57,11 @@ exports.getTestsFromArgs = function (testType, onFile, args = {}) {
       return skipTest(name, args.skipVM)
     }
   }
-
+  
+  if (args.dir) {
+    testDir = args.dir
+  }
+  
   if (args.file) {
     fileFilter = new RegExp(args.file)
   }
@@ -66,7 +71,7 @@ exports.getTestsFromArgs = function (testType, onFile, args = {}) {
       return testName !== args.test
     }
   }
-  return getTests(testType, onFile, fileFilter, skipFn)
+  return getTests(testType, onFile, testDir, fileFilter, skipFn)
 }
 
 exports.getSingleFile = (file) => {

--- a/index.js
+++ b/index.js
@@ -8,13 +8,14 @@ const path = require('path')
  * @param {Object} tests the tests usally fetched using `getTests`
  * @param {Function} filter to enable test skipping, called with skipFn(index, testName, testData)
  */
-const getTests = exports.getTests = (testType, onFile, testDir = '', fileFilter = /.json$/, skipFn = () => {
+const getTests = exports.getTests = (testType, onFile, testDir = '', fileFilter = /.json$/, excludeDir = '', skipFn = () => {
   return false
 }) => {
   return new Promise((resolve, reject) => {
     var testPath = path.join(__dirname, 'tests', testType, testDir)
     dir.readFiles(testPath, {
-      match: fileFilter
+      match: fileFilter,
+      excludeDir: excludeDir
     }, async (err, content, fileName, next) => {
       if (err) reject(err)
 
@@ -39,7 +40,7 @@ function skipTest (testName, skipList = []) {
 }
 
 exports.getTestsFromArgs = function (testType, onFile, args = {}) {
-  let testDir, fileFilter, skipFn
+  let testDir, fileFilter, excludeDir, skipFn
 
   skipFn = (name) => {
     return skipTest(name, args.skipTests)
@@ -65,13 +66,17 @@ exports.getTestsFromArgs = function (testType, onFile, args = {}) {
   if (args.file) {
     fileFilter = new RegExp(args.file)
   }
+  
+  if (args.excludeDir) {
+    excludeDir = new RegExp(args.excludeDir)
+  }
 
   if (args.test) {
     skipFn = (testName) => {
       return testName !== args.test
     }
   }
-  return getTests(testType, onFile, testDir, fileFilter, skipFn)
+  return getTests(testType, onFile, testDir, fileFilter, excludeDir, skipFn)
 }
 
 exports.getSingleFile = (file) => {


### PR DESCRIPTION
This PR reintegrates the other ``BlockchainTests`` by removing the restriction to the subfolder ``GeneralStateTests``.

Instead it introduces a new CL argument ``dir``, which can now be used to limit test runs to a certain folder or subfolder, e.g. with ``dir=GeneralStateTests`` or dir=GeneralStateTests/stCallCodes``. A second CL argument ``excludeDir`` can be used to exclude directories from being read.

The PR also adds two example scripts to run the test methods and a short API description in the README file.