### PR TITLE
Replaced async/await usage with library version for Node 6 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const dir = require('node-dir')
 const path = require('path')
+var asyncFromLib = require('asyncawait/async')
+var awaitFromLib = require('asyncawait/await')
 
 /**
  * Runs a battery of tests
@@ -11,29 +13,24 @@ const path = require('path')
  */
 const getTests = exports.getTests = (testType, onFile, fileFilter = /.json$/, skipFn = () => {
   return false
-}, testDir = '', excludeDir = '', testsPath = __dirname + '/tests') => { // eslint-disable-line 
+}, testDir = '', excludeDir = '', testsPath = __dirname + '/tests') => { // eslint-disable-line
   return new Promise((resolve, reject) => {
     dir.readFiles(path.join(testsPath, testType, testDir), {
       match: fileFilter,
       excludeDir: excludeDir
-    }, (err, content, fileName, next) => {
+    }, asyncFromLib((err, content, fileName, next) => {
       if (err) reject(err)
 
       fileName = path.parse(fileName).name
       const tests = JSON.parse(content)
-      let promise = Promise.resolve()
 
       for (let testName in tests) {
         if (!skipFn(testName)) {
-          promise.then(() => {
-            onFile(fileName, testName, tests[testName])
-          })
+          awaitFromLib(onFile(fileName, testName, tests[testName]))
         }
       }
-      promise.then(() => {
-        next()
-      })
-    }, (err, files) => {
+      next()
+    }), (err, files) => {
       if (err) reject(err)
       resolve(files)
     })

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "mjbecze <mjbecze@gmail.com>",
   "license": "MPL-2.0",
   "dependencies": {
+    "asyncawait": "^1.0.6",
     "node-dir": "^0.1.16"
   },
   "devDependencies": {


### PR DESCRIPTION
This is another  patch for re-enabling Node 6 support, since the ``Promise`` based solution introduced in the (merged) PR before turned out to have memory-overflow as side effect when running a lot of blockchain tests in sequence.

This solution both fixes the memory-overflow issue and keeps the wanted async/await behaviour. 