### PR TITLE
chore(package): update tape to version 4.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "standard": "^10.0.3",
-    "tape": "^4.8.0"
+    "tape": "^4.10.1"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Have triggered this from within the corresponding Greenkeeper issue https://github.com/ethereumjs/ethereumjs-testing/issues/35 (by clicking "explicitly upgrade to this version").

Never used this functionality before, will see how it goes.