### PR TITLE
Clean up getTests function, remove async/await library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 language: node_js
-node_js:
-  - "8"
-  - "10"
-env:
-  - CXX=g++-4.8
 addons:
   apt:
     sources:
@@ -14,15 +9,17 @@ addons:
 env:
   global:
     - DISPLAY=:99.0
-  matrix:
-    - CXX=g++-4.8 TEST_SUITE=test
+    - CXX=g++-4.8
 matrix:
   fast_finish: true
   include:
     - os: linux
       node_js: "8"
-      env: CXX=g++-4.8 TEST_SUITE=lint
+      env: TEST_SUITE=lint
     - os: linux
       node_js: "8"
-      env: CXX=g++-4.8 TEST_SUITE=test
+      env: TEST_SUITE=test
+    - os: linux
+      node_js: "10"
+      env: TEST_SUITE=test
 script: npm run $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
+  - "10"
 env:
   - CXX=g++-4.8
 addons:
@@ -20,9 +20,9 @@ matrix:
   fast_finish: true
   include:
     - os: linux
-      node_js: "6"
+      node_js: "8"
       env: CXX=g++-4.8 TEST_SUITE=lint
     - os: linux
-      node_js: "6"
+      node_js: "8"
       env: CXX=g++-4.8 TEST_SUITE=test
 script: npm run $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
     - CXX=g++-4.8
 matrix:
   fast_finish: true
+  allowed_failures:
+    - node_js: "node"
   include:
     - os: linux
       node_js: "8"
@@ -21,5 +23,8 @@ matrix:
       env: TEST_SUITE=test
     - os: linux
       node_js: "10"
+      env: TEST_SUITE=test
+    - os: linux
+      node_js: "node"
       env: TEST_SUITE=test
 script: npm run $TEST_SUITE

--- a/index.js
+++ b/index.js
@@ -5,6 +5,17 @@ const path = require('path')
 const falsePredicate = () => false
 const defaultTestsPath = path.join(__dirname, 'tests')
 
+/**
+ * Returns the list of test files matching the given parameters
+ * @param {string} testType the test type (path segment)
+ * @param {Function} onFile a callback for each file
+ * @param {RegExp|Array<string>} fileFilter a {@code RegExp} or array to specify filenames to operate on
+ * @param {Function<boolean>} skipPredicate a filtering function for test names
+ * @param {string} testDir the directory inside the {@code tests/} directory to use
+ * @param {RegExp|Array<string>} excludeDir a {@code RegExp} or array to specify directories to ignore
+ * @param {string} testsPath the path to the {@code tests/} directory
+ * @return {Promise<Array<string>>} the list of test files
+ */
 const getTests = exports.getTests = (
   testType,
   onFile,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "author": "mjbecze <mjbecze@gmail.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "asyncawait": "^1.0.6",
     "node-dir": "^0.1.16"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,12 @@ tape('Test access tests', function (t) {
     st.end()
   })
 
+  t.test('should read tests', async function (st) {
+    const allTestFiles = await testing.getTests('BlockchainTests', () => {})
+    st.ok(allTestFiles.length !== 0, 'empty test list')
+    st.end()
+  })
+
   t.test('should read tests from args', function (st) {
     let args = {}
     args.dir = 'GeneralStateTests/stCallCodes'


### PR DESCRIPTION
Fixes #37

This PR cleans up `getTests`, also replacing the async-await library with native `async`/`await`.